### PR TITLE
replacing envmodules with singularity

### DIFF
--- a/workflow/rules/create_filtered_fastq.smk
+++ b/workflow/rules/create_filtered_fastq.smk
@@ -48,8 +48,8 @@ if config["new_fastq"]:
         resources:
             mem=calc_mem_gb,
             hrs=72,
-        container:
-        "docker://eichlerlab/back-reference-qc:0.1",
+        container: 
+            "docker://eichlerlab/back-reference-qc:0.1",
         shell:
             """
             seqtk subseq {input.fastq} {input.target_reads} > {output.subsetted_fastq}


### PR DESCRIPTION
replacing envmodules with singularity ( docker://eichlerlab/back-reference-qc:0.1)